### PR TITLE
Reduced the amount of data read in for Eurostat data

### DIFF
--- a/R/set_sws_dev_settings.R
+++ b/R/set_sws_dev_settings.R
@@ -37,7 +37,7 @@ set_sws_dev_settings <- function(localsettingspath = NULL) {
 
     share_drive <- file.path(SETTINGS[['share']])
 
-    if (!is.na(share_drive) & file.exists(share_drive)) {
+    if (!is.null(share_drive) && !is.na(share_drive) && length(share_drive) > 0L && file.exists(share_drive)) {
       flog.debug("A valid 'share' variable was found in %s",
                  localsettingspath, name = "dev")
       Sys.setenv("R_SWS_SHARE_PATH" = share_drive)


### PR DESCRIPTION
I'm writing a best practices guide for writing modules. I was looking at the trade module for examples as it's a long module that has been optimised several times over its life for performance.

While doing so, I found a spot where the amount of data read in could be reduced, possibly shaving a few seconds off the total time. I also modified the share drive check so that it would work on my machine.